### PR TITLE
Stop listing the makefiles from libraries

### DIFF
--- a/src/main/kotlin/name/kropp/intellij/makefile/MakefileTargetKeyIndex.kt
+++ b/src/main/kotlin/name/kropp/intellij/makefile/MakefileTargetKeyIndex.kt
@@ -15,7 +15,7 @@ object MakefileTargetIndex : StringStubIndexExtension<MakefileTarget>() {
   fun allTargets(project: Project): List<MakefileTarget> {
     val allTargets = mutableSetOf<String>()
     processAllKeys(project, CommonProcessors.CollectProcessor(allTargets))
-    return allTargets.flatMap { get(it, project, GlobalSearchScope.allScope(project)) }
+    return allTargets.flatMap { get(it, project, GlobalSearchScope.projectScope(project)) }
   }
 
   override fun getKey(): StubIndexKey<String, MakefileTarget> = TARGET_INDEX_KEY


### PR DESCRIPTION
Search for the targets in the project scope instead of the global scope to avoid listing the makefiles from libraries in the tool window.

I am not very familiar with the IntelliJ Platform SDK, so please let me know if I am missing something. The manual test was performed on a Go module project where makefiles are being picked up from the Go SDK.